### PR TITLE
Fix typo in the repo link

### DIFF
--- a/src/commands/about.rs
+++ b/src/commands/about.rs
@@ -55,7 +55,7 @@ pub async fn about(ctx: Context<'_>) -> Result<(), Error> {
         )
         .field(
             "__Github Repository__",
-            "[Github Repository](https://github.com/Alekuso/Button-Clicker-Bot)",
+            "[Github Repository](https://github.com/Alekuso/Button-Clicker)",
             false,
         )
         .thumbnail(thumbnail)


### PR DESCRIPTION
Fixes a typo in a link to the repository

`Button-Clicker-Bot` -> `Button-Clicker`