### PR TITLE
Deletes the active session before trying to delete the message

### DIFF
--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -131,6 +131,7 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
 
                 // Delete the message if the user clicks on the stop session button
                 if interaction.data.custom_id.as_str() != "click" {
+                    delete_session(ctx, collection_session).await?;
                     msg.delete(ctx).await?;
                     break;
                 }
@@ -150,13 +151,12 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
             }
 
             None => {
+                delete_session(ctx, collection_session).await?;
                 msg.delete(ctx).await?;
                 break;
             }
         }
     }
-
-    delete_session(ctx, collection_session).await?;
 
     info!(
         "Terminating session for {} | Time {:?}",


### PR DESCRIPTION
The session thread “crashes” if it tries to delete a message that has already been deleted or that does not exist (from being removed from the server, for example)
This fix forces the removal of the session before trying to delete the message.
An error handler is not needed when deleting messages in this case because in a normal situation, the thread will always end after deleting the message.