### PR TITLE
Removes the session feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Alex Olemans <alex@tanukii.dev>"]
 [profile.release]
 opt-level = 3
 lto = true
-codegen-units = 1
+# codegen-units = 1
 strip = false
 
 [dependencies]

--- a/src/commands/leaderboard.rs
+++ b/src/commands/leaderboard.rs
@@ -36,7 +36,7 @@ pub async fn leaderboard(ctx: Context<'_>) -> Result<(), Error> {
     let db = &ctx.data().db;
     let collection: Collection<Document> = db.collection("users");
 
-    let users = get_users(collection.clone(), Filter::ScoreDesc).await?;
+    let users = get_users(&collection, Filter::ScoreDesc).await?;
 
     let embed = make_embed(ctx, users, Filter::ScoreDesc).await;
 
@@ -67,11 +67,11 @@ pub async fn leaderboard(ctx: Context<'_>) -> Result<(), Error> {
         // Handle which button has been pressed
         let embed = match interaction.data.custom_id.as_str() {
             "asc" => {
-                let users = get_users(collection.clone(), Filter::ScoreAsc).await?;
+                let users = get_users(&collection, Filter::ScoreAsc).await?;
                 make_embed(ctx, users, Filter::ScoreAsc).await
             }
             "desc" => {
-                let users = get_users(collection.clone(), Filter::ScoreDesc).await?;
+                let users = get_users(&collection, Filter::ScoreDesc).await?;
                 make_embed(ctx, users, Filter::ScoreDesc).await
             }
             _ => {
@@ -96,7 +96,7 @@ pub async fn leaderboard(ctx: Context<'_>) -> Result<(), Error> {
 }
 
 async fn get_users(
-    collection: Collection<Document>,
+    collection: &Collection<Document>,
     filter: Filter,
 ) -> Result<Vec<Document>, Error> {
     let cursor = match filter {

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -29,18 +29,6 @@ use tracing::info;
 pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
     let time = std::time::Instant::now();
     let db = &ctx.data().db;
-    let collection_session: Collection<Document> = db.collection("session");
-
-    // !!!: Session is disabled for now.
-    // Checks if the session already exists
-    /*    let session = collection_session
-        .find_one(doc! {"user_id": ctx.author().id.to_string()})
-        .await?;
-    if session.is_some() {
-        return Err("You already have an active session!".into());
-    }*/
-
-    create_session(ctx, collection_session.clone()).await?;
 
     // Checks if the user has an account
     // It creates a new account if the user doesn't have one
@@ -132,7 +120,6 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
 
                 // Delete the message if the user clicks on the stop session button
                 if interaction.data.custom_id.as_str() != "click" {
-                    delete_session(ctx, collection_session).await?;
                     msg.delete(ctx).await?;
                     break;
                 }
@@ -156,7 +143,6 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
             }
 
             None => {
-                delete_session(ctx, collection_session).await?;
                 msg.delete(ctx).await?;
                 break;
             }
@@ -183,26 +169,6 @@ fn make_embed(ctx: Context<'_>, counter: i64) -> CreateEmbed {
         .color(0x5754d0)
         .thumbnail(thumbnail)
         .footer(footer)
-}
-
-async fn create_session(_ctx: Context<'_>, _collection: Collection<Document>) -> Result<(), Error> {
-    /*    collection
-            .insert_one(doc! {
-                "user_id": ctx.author().id.to_string(),
-            })
-            .await?;
-    */
-    Ok(())
-}
-
-async fn delete_session(_ctx: Context<'_>, _collection: Collection<Document>) -> Result<(), Error> {
-    /*    collection
-            .delete_one(doc! {
-                "user_id": ctx.author().id.to_string()
-            })
-            .await?;
-    */
-    Ok(())
 }
 
 pub async fn create_user(ctx: Context<'_>, collection: Collection<Document>) -> Result<(), Error> {

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -148,7 +148,7 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
                     .create_response(ctx, CreateInteractionResponse::Acknowledge)
                     .await?;
 
-                info!("Increase Counter | Time: {:?}", interaction_time.elapsed());
+                info!("Increase Counter for {} | Time: {:?}", ctx.author().id.to_string(), interaction_time.elapsed());
             }
 
             None => {

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -33,7 +33,7 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
 
     // !!!: Session is disabled for now.
     // Checks if the session already exists
-/*    let session = collection_session
+    /*    let session = collection_session
         .find_one(doc! {"user_id": ctx.author().id.to_string()})
         .await?;
     if session.is_some() {
@@ -148,7 +148,11 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
                     .create_response(ctx, CreateInteractionResponse::Acknowledge)
                     .await?;
 
-                info!("Increase Counter for {} | Time: {:?}", ctx.author().id.to_string(), interaction_time.elapsed());
+                info!(
+                    "Increase Counter for {} | Time: {:?}",
+                    ctx.author().id.to_string(),
+                    interaction_time.elapsed()
+                );
             }
 
             None => {
@@ -182,22 +186,22 @@ fn make_embed(ctx: Context<'_>, counter: i64) -> CreateEmbed {
 }
 
 async fn create_session(_ctx: Context<'_>, _collection: Collection<Document>) -> Result<(), Error> {
-/*    collection
-        .insert_one(doc! {
-            "user_id": ctx.author().id.to_string(),
-        })
-        .await?;
-*/
+    /*    collection
+            .insert_one(doc! {
+                "user_id": ctx.author().id.to_string(),
+            })
+            .await?;
+    */
     Ok(())
 }
 
 async fn delete_session(_ctx: Context<'_>, _collection: Collection<Document>) -> Result<(), Error> {
-/*    collection
-        .delete_one(doc! {
-            "user_id": ctx.author().id.to_string()
-        })
-        .await?;
-*/
+    /*    collection
+            .delete_one(doc! {
+                "user_id": ctx.author().id.to_string()
+            })
+            .await?;
+    */
     Ok(())
 }
 

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -38,7 +38,7 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
         .await?;
     let mut counter: i64;
     if user.is_none() {
-        create_user(ctx, collection_user.clone()).await?;
+        create_user(ctx, &collection_user).await?;
         counter = 0;
     } else {
         counter = user.clone().unwrap().get_i64("counter").unwrap();
@@ -124,7 +124,7 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
                     break;
                 }
 
-                increase_counter(ctx, collection_user.clone(), &mut counter).await?;
+                increase_counter(ctx, &collection_user, &mut counter).await?;
 
                 let mut new_msg = interaction.message.clone();
                 new_msg
@@ -171,7 +171,7 @@ fn make_embed(ctx: Context<'_>, counter: i64) -> CreateEmbed {
         .footer(footer)
 }
 
-pub async fn create_user(ctx: Context<'_>, collection: Collection<Document>) -> Result<(), Error> {
+pub async fn create_user(ctx: Context<'_>, collection: &Collection<Document>) -> Result<(), Error> {
     collection
         .insert_one(doc! {
             "user_id": ctx.author().id.to_string(),
@@ -186,7 +186,7 @@ pub async fn create_user(ctx: Context<'_>, collection: Collection<Document>) -> 
 
 async fn increase_counter(
     ctx: Context<'_>,
-    collection: Collection<Document>,
+    collection: &Collection<Document>,
     counter: &mut i64,
 ) -> Result<(), Error> {
     collection
@@ -208,7 +208,7 @@ async fn increase_counter(
     Ok(())
 }
 
-async fn fetch_score(ctx: Context<'_>, collection: Collection<Document>) -> Result<i64, Error> {
+async fn fetch_score(ctx: Context<'_>, collection: &Collection<Document>) -> Result<i64, Error> {
     let user = collection
         .find_one(doc! {"user_id": ctx.author().id.to_string()})
         .await?;

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -31,13 +31,14 @@ pub async fn play(ctx: Context<'_>) -> Result<(), Error> {
     let db = &ctx.data().db;
     let collection_session: Collection<Document> = db.collection("session");
 
+    // !!!: Session is disabled for now.
     // Checks if the session already exists
-    let session = collection_session
+/*    let session = collection_session
         .find_one(doc! {"user_id": ctx.author().id.to_string()})
         .await?;
     if session.is_some() {
         return Err("You already have an active session!".into());
-    }
+    }*/
 
     create_session(ctx, collection_session.clone()).await?;
 
@@ -180,23 +181,23 @@ fn make_embed(ctx: Context<'_>, counter: i64) -> CreateEmbed {
         .footer(footer)
 }
 
-async fn create_session(ctx: Context<'_>, collection: Collection<Document>) -> Result<(), Error> {
-    collection
+async fn create_session(_ctx: Context<'_>, _collection: Collection<Document>) -> Result<(), Error> {
+/*    collection
         .insert_one(doc! {
             "user_id": ctx.author().id.to_string(),
         })
         .await?;
-
+*/
     Ok(())
 }
 
-async fn delete_session(ctx: Context<'_>, collection: Collection<Document>) -> Result<(), Error> {
-    collection
+async fn delete_session(_ctx: Context<'_>, _collection: Collection<Document>) -> Result<(), Error> {
+/*    collection
         .delete_one(doc! {
             "user_id": ctx.author().id.to_string()
         })
         .await?;
-
+*/
     Ok(())
 }
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -34,7 +34,7 @@ pub async fn sync(ctx: Context<'_>) -> Result<(), Error> {
         .await?;
 
     if user.is_none() {
-        create_user(ctx, collection.clone()).await?;
+        create_user(ctx, &collection).await?;
     }
 
     // Force update all infos


### PR DESCRIPTION
This is not a definitive fix. Another system will replace the session later.
Fixes #7 

This only comments out the session registration/removal and verification from the play command.
The score doesn't matter much, so having a duplicate of the play session won't do much in the end.